### PR TITLE
Increase max content length to avoid CloudWanderer exceeding the max …

### DIFF
--- a/docker-graph-notebook-gremlin-server/conf/gremlin-server.yaml
+++ b/docker-graph-notebook-gremlin-server/conf/gremlin-server.yaml
@@ -68,7 +68,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 65536
+maxContentLength: 131072
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768


### PR DESCRIPTION
…size