### PR TITLE
Increase the maxContentLength to 10MB to match upcoming release

### DIFF
--- a/docker-graph-notebook-gremlin-server/conf/gremlin-server.yaml
+++ b/docker-graph-notebook-gremlin-server/conf/gremlin-server.yaml
@@ -68,7 +68,7 @@ keepAliveInterval: 0
 maxInitialLineLength: 4096
 maxHeaderSize: 8192
 maxChunkSize: 8192
-maxContentLength: 131072
+maxContentLength: 10485760
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768


### PR DESCRIPTION
The reflects the (as yet unreleased) change in the main docker config. 
https://github.com/apache/tinkerpop/commit/fd1fd10e23fe15822ded07527574c6ccdf5c4484#diff-fda67ac603922d601d1402f6c1bc59f33114c9e09501ec971f2f4ea4697d6f1dL48